### PR TITLE
Add query parameter to disable automatic partials resolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following query options are supported:
  - *inlineRequires*: Defines a regex that identifies strings within helper/partial parameters that should be replaced by inline require statements.
  - *rootRelative*: When automatically resolving partials and helpers, use an implied root path if none is present. Default = `./`. Setting this to be empty effectively turns off automatically resolving relative handlebars resources for items like `{{helper}}`. `{{./helper}}` will still resolve as expected.
  - *knownHelpers*: Array of helpers that are registered at runtime and should not explicitly be required by webpack. This helps with interoperability for libraries like Thorax [helpers](http://thoraxjs.org/api.html#template-helpers).
+ - *disablePartialResolving*: Set it to `true` if you don't want the loader to resolve partials automatically. (you will need to do it yourself). Defaults to `false`: the loader will resolve partials
  - *debug*: Shows trace information to help debug issues (e.g. resolution of helpers).
 
 See [`webpack`](https://github.com/webpack/webpack) documentation for more information regarding loaders.

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = function(source) {
 	var loaderApi = this;
 	var query = this.query instanceof Object ? this.query : loaderUtils.parseQuery(this.query);
 	var runtimePath = query.runtime || require.resolve("handlebars/runtime");
+	var isPartialsResolvingDisabled = query.disablePartialsResolving || false;
 
 	if (!versionCheck(handlebars, require(runtimePath))) {
 		throw new Error('Handlebars compiler version does not match runtime version');
@@ -267,7 +268,9 @@ module.exports = function(source) {
 			}
 
 			// Resolve path for each partial
-			async.forEach(Object.keys(foundPartials), resolvePartialsIterator, doneResolving);
+			// Can be disabled through the query
+			var partialsToResolve = isPartialsResolvingDisabled ? {} : foundPartials;
+			async.forEach(Object.keys(partialsToResolve), resolvePartialsIterator, doneResolving);
 		};
 
 		var resolveUnclearStuff = function(err) {


### PR DESCRIPTION
When using parameter `disablePartialsResolving` we can tell the loader that the partials will be declared manually, and it should not require the discovered partials.
