### PR TITLE
Add query parameter for path to another Handlebars compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,11 @@ module.exports = function(source) {
 	var runtimePath = query.runtime || require.resolve("handlebars/runtime");
 	var isPartialsResolvingDisabled = query.disablePartialsResolving || false;
 
+	// Let user give another compiler if handlebars module in package.json is not the right version
+	if (query.handlebarsCompiler) {
+		handlebars = require(query.handlebarsCompiler);
+	}
+
 	if (!versionCheck(handlebars, require(runtimePath))) {
 		throw new Error('Handlebars compiler version does not match runtime version');
 	}


### PR DESCRIPTION
By default, `handlebars-loader` retrieve Handlebars from the project's package.json. This is a very good idea. 

But we have an edge case where this is not the right version. This PR allows overriding the default behavior by adding a query parameter for the HBS compiler path.
