### PR TITLE
Add query parameter for auto-registering partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A [`handlebars`](http://handlebarsjs.com) template loader for [`webpack`](https:
 
 What this fork adds:
 - Query parameter to disable the automatic resolving of discovered partials when precompiling the template files. This means all the partials needs to be registered "manually" before using them.
+- Query parameter to add the `registerPartial` statement directly in the produced template file
 - Query parameter to specify the path to the Handlebars compiler to use. By default `handlebars-loader` takes the compiler from handlebars module declared in the project's package.json
 
 ## General Usage
@@ -58,6 +59,7 @@ The following query options are supported:
  - *knownHelpers*: Array of helpers that are registered at runtime and should not explicitly be required by webpack. This helps with interoperability for libraries like Thorax [helpers](http://thoraxjs.org/api.html#template-helpers).
  - *disablePartialResolving*: Set it to `true` if you don't want the loader to resolve partials automatically. (you will need to do it yourself). Defaults to `false`: the loader will resolve partials
  - *handlebarsCompiler*: Specify the path to the handlebars compiler library. Defaults will automatically retrieve the compiler from the handlebars module declared in the project's package.json
+ - *autoRegisterPartials*: Set it to `true` if you want to insert a `registerPartial` statement in the compiled template file. The name of the partial will be its path from the resolving root defined in Webpack's config, without the .hbs extension
  - *debug*: Shows trace information to help debug issues (e.g. resolution of helpers).
 
 See [`webpack`](https://github.com/webpack/webpack) documentation for more information regarding loaders.


### PR DESCRIPTION
This PR adds a query parameter that will insert the Handlebars `registerPartial` statement in the produced file. The name of the partial will be its path from the resolving root defined in Webpack config.
